### PR TITLE
Update to github-styled svg icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ You may have to reload obsidian (`ctrl+R`) to see changes.
 
 # Version History
 
+## v0.2.1
+Forked project to update manifest.json
+
 ## v0.2.0
 Add excluded languages, currently only includes "todoist" to be compatible with the todoist plugin. Will add setting page to add custom exclude languages in future.
 

--- a/main.ts
+++ b/main.ts
@@ -5,8 +5,8 @@ const excludeLangs = [
   "todoist"
 ];
 
-const svgCopy = '<svg viewBox="0 0 100 100" width="20" height="20" class="documents"><path fill="currentColor" stroke="currentColor" d="M74,4c-0.1,0-0.2,0-0.3,0H40v11.5l4,4V8h28v20h20v48H64v4h32V26.3c0-0.2,0-0.4,0-0.6v-0.5l-0.4-0.4 c-0.1-0.1-0.2-0.3-0.4-0.4c0,0,0,0,0,0L75.6,4.8c-0.1-0.1-0.2-0.3-0.4-0.4L74.8,4h-0.5C74.2,4,74.1,4,74,4L74,4z M76,10.8L89.2,24 H76V10.8z M38,20c-0.1,0-0.2,0-0.3,0H4v76h56V42.3c0-0.2,0-0.4,0-0.6v-0.5l-0.4-0.4c-0.1-0.1-0.2-0.3-0.4-0.4L39.6,20.7 c-0.1-0.1-0.2-0.3-0.4-0.4L38.8,20h-0.5C38.2,20,38.1,20,38,20z M8,24h28v20h20v48H8L8,24z M40,26.8L53.2,40H40V26.8z M60.5,36 l4,4H84v-4L60.5,36z M64,48v4h12v-4H64z M16,52v4h32v-4H16z M64,60v4h20v-4H64z M16,64v4h24v-4H16z M16,76v4h32v-4H16z"></path></svg>';
-
+const svgCopy = '<svg height="16" width="16" viewBox="0 0 16 16" version="1.1" data-view-component="true" class="copy"><path fill-rule="evenodd" d="M5.75 1a.75.75 0 00-.75.75v3c0 .414.336.75.75.75h4.5a.75.75 0 00.75-.75v-3a.75.75 0 00-.75-.75h-4.5zm.75 3V2.5h3V4h-3zm-2.874-.467a.75.75 0 00-.752-1.298A1.75 1.75 0 002 3.75v9.5c0 .966.784 1.75 1.75 1.75h8.5A1.75 1.75 0 0014 13.25v-9.5a1.75 1.75 0 00-.874-1.515.75.75 0 10-.752 1.298.25.25 0 01.126.217v9.5a.25.25 0 01-.25.25h-8.5a.25.25 0 01-.25-.25v-9.5a.25.25 0 01.126-.217z"></path></svg>';
+const svgSuccess = '<svg height="16" width="16" viewBox="0 0 16 16" version="1.1" data-view-component="true" class="copy-success"><path fill-rule="evenodd" d="M13.78 4.22a.75.75 0 010 1.06l-7.25 7.25a.75.75 0 01-1.06 0L2.22 9.28a.75.75 0 011.06-1.06L6 10.94l6.72-6.72a.75.75 0 011.06 0z"></path></svg>';
 
 export default class CMSyntaxHighlightPlugin extends Plugin {
 
@@ -49,7 +49,7 @@ export default class CMSyntaxHighlightPlugin extends Plugin {
 
       const button = document.createElement('div');
       button.className = 'copy-code-button';
-      button.setAttribute('aria-label', 'Copy code block');
+      button.setAttribute('aria-label', 'Copy');
       button.innerHTML = svgCopy;
 
       button.addEventListener('click', function () {
@@ -58,7 +58,7 @@ export default class CMSyntaxHighlightPlugin extends Plugin {
                   leaving the button in a focused state. */
               button.blur();
 
-              button.innerText = 'Code has been copied!';
+              button.innerHTML = svgSuccess;
 
               setTimeout(function () {
                   button.innerHTML = svgCopy;

--- a/main.ts
+++ b/main.ts
@@ -5,6 +5,8 @@ const excludeLangs = [
   "todoist"
 ];
 
+const svgCopy = '<svg viewBox="0 0 100 100" width="20" height="20" class="documents"><path fill="currentColor" stroke="currentColor" d="M74,4c-0.1,0-0.2,0-0.3,0H40v11.5l4,4V8h28v20h20v48H64v4h32V26.3c0-0.2,0-0.4,0-0.6v-0.5l-0.4-0.4 c-0.1-0.1-0.2-0.3-0.4-0.4c0,0,0,0,0,0L75.6,4.8c-0.1-0.1-0.2-0.3-0.4-0.4L74.8,4h-0.5C74.2,4,74.1,4,74,4L74,4z M76,10.8L89.2,24 H76V10.8z M38,20c-0.1,0-0.2,0-0.3,0H4v76h56V42.3c0-0.2,0-0.4,0-0.6v-0.5l-0.4-0.4c-0.1-0.1-0.2-0.3-0.4-0.4L39.6,20.7 c-0.1-0.1-0.2-0.3-0.4-0.4L38.8,20h-0.5C38.2,20,38.1,20,38,20z M8,24h28v20h20v48H8L8,24z M40,26.8L53.2,40H40V26.8z M60.5,36 l4,4H84v-4L60.5,36z M64,48v4h12v-4H64z M16,52v4h32v-4H16z M64,60v4h20v-4H64z M16,64v4h24v-4H16z M16,76v4h32v-4H16z"></path></svg>';
+
 
 export default class CMSyntaxHighlightPlugin extends Plugin {
 
@@ -26,42 +28,45 @@ export default class CMSyntaxHighlightPlugin extends Plugin {
   }
 
   addCopyButtons(clipboard:any) {
-    document.querySelectorAll('pre > code').forEach(function (codeBlock) {
+    document.querySelectorAll('pre > code').forEach(function (codeBlock: HTMLElement) {
 
-      var pre = codeBlock.parentNode;
+      const pre = codeBlock.parentNode as HTMLPreElement;
       
       // check for excluded langs
       for ( let lang of excludeLangs ){
-        if (pre.classList.contains( `language-${lang}` ))
+        if (pre.classList.contains(`language-${lang}`))
           return;
       }
 
-      // Dont add more than once
-      if (pre.parentNode.classList.contains('has-copy-button')) {
+      const parent = pre.parentNode as HTMLDivElement;
+
+      // don't add more than once
+      if (parent.classList.contains('has-copy-button')) {
         return;
       }
-      pre.parentNode.classList.add( 'has-copy-button' );
 
-        var button = document.createElement('button');
-        button.className = 'copy-code-button';
-        button.type = 'button';
-        button.innerText = 'Copy';
-  
-        button.addEventListener('click', function () {
-            clipboard.writeText(codeBlock.innerText).then(function () {
-                /* Chrome doesn't seem to blur automatically,
-                   leaving the button in a focused state. */
-                button.blur();
-  
-                button.innerText = 'copied!';
-  
-                setTimeout(function () {
-                    button.innerText = 'copy';
-                }, 2000);
-            }, function (error) {
-                button.innerText = 'Error';
-            });
-        });
+      parent.classList.add('has-copy-button');
+
+      const button = document.createElement('div');
+      button.className = 'copy-code-button';
+      button.setAttribute('aria-label', 'Copy code block');
+      button.innerHTML = svgCopy;
+
+      button.addEventListener('click', function () {
+          clipboard.writeText(codeBlock.innerText).then(function () {
+              /* Chrome doesn't seem to blur automatically,
+                  leaving the button in a focused state. */
+              button.blur();
+
+              button.innerText = 'Code has been copied!';
+
+              setTimeout(function () {
+                  button.innerHTML = svgCopy;
+              }, 2000);
+          }, function () {
+              button.innerText = 'An error occurred!';
+          });
+      });
   
         pre.appendChild(button);
         

--- a/manifest.json
+++ b/manifest.json
@@ -1,8 +1,8 @@
 {
   "id": "code-block-copy",
-  "name": "Copy button for code blocks (fixed version manifest)",
+  "name": "Copy button for code blocks (Github Icon)",
   "author": "Daniel Brandenburg",
-  "description": "Temporary version fix released by Nathaniel Palmer of source project by Daniel Brandenburg (https:\/\/github.com\/jdbrice\/obsidian-code-block-copy)",
+  "description": "Temporary version fix released by Tyler Harris of source project by Daniel Brandenburg (https:\/\/github.com\/jdbrice\/obsidian-code-block-copy)",
   "isDesktopOnly": false,
-  "version": "0.2.1"
+  "version": "0.2.2"
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,8 +1,8 @@
 {
   "id": "code-block-copy",
-  "name": "Copy button for code blocks",
+  "name": "Copy button for code blocks (fixed version manifest)",
   "author": "Daniel Brandenburg",
-  "description": "Copy button for code blocks",
+  "description": "Temporary version fix released by Nathaniel Palmer of source project by Daniel Brandenburg (https:\/\/github.com\/jdbrice\/obsidian-code-block-copy)",
   "isDesktopOnly": false,
-  "version": "0.2.0"
+  "version": "0.2.1"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "code-block-copy",
-  "version": "0.1.0",
+  "version": "0.2.1",
   "description": "Copy button for code blocks",
   "main": "main.js",
   "scripts": {

--- a/styles.scss
+++ b/styles.scss
@@ -1,23 +1,31 @@
 
 .copy-code-button {
-  color: var(--text-faint);
-
   /* right-align */
-  display: block;
+  display: none;
   margin-left: auto;
   margin-right: 0;
 
   margin-bottom: -2px;
-  padding: 3px 8px;
-  font-size: 0.8em;
+  padding: 12px;
 
   position: absolute;
   top: 0px;
   right: 0px;
 
+  svg.copy path {
+    fill: var(--interactive-normal);
+  }
+
   &:hover, &:active {
     cursor: pointer;
-    color: var(--interactive-accent-hover);
+    svg path {
+      fill: var(--interactive-accent-hover);
+      transition: all ease 0.3s;
+    }
+  }
+
+  svg.copy-success path {
+    fill: var(--interactive-success);
   }
 
   &:focus {
@@ -25,11 +33,11 @@
   }
 }
 
-.highlight pre {
-  /* Avoid pushing up the copy buttons. */
-  margin: 0;
-}
-
-.has-copy-button {
+.has-copy-button pre {
   position: relative;
+  &:hover {
+    .copy-code-button {
+      display: block;
+    }
+  }
 }

--- a/styles.scss
+++ b/styles.scss
@@ -6,7 +6,7 @@
   margin-right: 0;
 
   margin-bottom: -2px;
-  padding: 12px;
+  padding: 3px 8px;
 
   position: absolute;
   top: 0px;

--- a/styles.scss
+++ b/styles.scss
@@ -1,8 +1,6 @@
 
 .copy-code-button {
-  color: var(--background-primary);
-  background-color: var(--text-faint);
-  border-radius: 1px 1px 0px 0px;
+  color: var(--text-faint);
 
   /* right-align */
   display: block;
@@ -16,23 +14,15 @@
   position: absolute;
   top: 0px;
   right: 0px;
-}
 
-.copy-code-button:hover {
-  cursor: pointer;
-  background-color: var(--text-normal);
-}
+  &:hover, &:active {
+    cursor: pointer;
+    color: var(--interactive-accent-hover);
+  }
 
-.copy-code-button:focus {
-  /* Avoid an ugly focus outline on click in Chrome,
-     but darken the button for accessibility.
-     See https://stackoverflow.com/a/25298082/1481479 */
-     background-color: var(--text-normal);
-  outline: 0;
-}
-
-.copy-code-button:active {
-  background-color: var(--text-normal);
+  &:focus {
+    outline: 0;
+  }
 }
 
 .highlight pre {


### PR DESCRIPTION
# Update to github-styled svg icons
I started from #6 and updated the following:
- change the svg icon for copy 
- add an svg icon for success
- remain hidden until hover of the code block (nice a tidy)
- fix an issue when the code block was nested within a list where the icon was being hoisted up

<p align="center">
    <img src="https://i.imgur.com/d4NuFAe.gif">
</p>